### PR TITLE
Generate markdown output for release notes at build time

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "dev": "next dev",
     "build": "next build",
-    "postbuild": "next-sitemap --config next-sitemap.config.js",
+    "postbuild": "node scripts/generate-release-notes-md.js && next-sitemap --config next-sitemap.config.js",
     "start": "next start",
     "lint": "next lint",
     "prepare": "husky install"

--- a/scripts/generate-release-notes-md.js
+++ b/scripts/generate-release-notes-md.js
@@ -1,0 +1,21 @@
+const fs = require("fs");
+const path = require("path");
+const matter = require("gray-matter");
+
+const SRC_DIR = path.join(__dirname, "..", "_release_notes");
+const OUT_DIR = path.join(__dirname, "..", "out", "release_notes");
+
+fs.mkdirSync(OUT_DIR, { recursive: true });
+
+const files = fs.readdirSync(SRC_DIR).filter((f) => f.endsWith(".md"));
+
+for (const file of files) {
+  const srcPath = path.join(SRC_DIR, file);
+  const raw = fs.readFileSync(srcPath, "utf8");
+  const { data, content } = matter(raw);
+  const title = data.title || "";
+  const body = `# ${title}\n\n${content.replace(/^\n+/, "")}`;
+  fs.writeFileSync(path.join(OUT_DIR, file), body);
+}
+
+console.log(`Generated ${files.length} markdown files in ${OUT_DIR}`);


### PR DESCRIPTION
## Summary

`/release_notes/<slug>.md` で各リリースノートの Markdown を取得できるようにします。ビルドの `postbuild` で `_release_notes/*.md` からフロントマターを除いた Markdown を生成し、タイトルを H1 として先頭に付与して `out/release_notes/<slug>.md` に出力します。

## Test plan

- [ ] ステージング/本番で `/release_notes/20260422.md` にアクセスして Markdown が返ること
- [ ] フロントマターが含まれないこと
- [ ] 1 行目がタイトルの `# ...` であること