### PR TITLE
Remove devel preview deploy and simplify workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,42 +8,9 @@ on:
   push:
     branches:
       - master
-      - devel
 
 jobs:
-  preview:
-    if: ${{ github.ref == 'refs/heads/devel' }}
-    runs-on: ubuntu-latest
-    environment:
-      name: preview
-      url: ${{ steps.deploy.outputs.url }}
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Setup node
-        uses: actions/setup-node@v4
-        with:
-          node-version: 20
-          cache: 'npm'
-          check-latest: true
-
-      - name: Install Vercel CLI
-        run: npm install --global vercel@latest
-
-      - name: Pull Vercel Environment Information
-        run: vercel pull --yes --environment=preview --token=${{ secrets.VERCEL_TOKEN }}
-
-      - name: Build Project Artifacts
-        run: vercel build --token=${{ secrets.VERCEL_TOKEN }}
-
-      - name: Deploy Project Artifacts to Vercel
-        id: deploy
-        run: echo "url=$(vercel deploy --prebuilt --token=${{ secrets.VERCEL_TOKEN }})" >> $GITHUB_OUTPUT
-
-      - run: vercel alias ${{ steps.deploy.outputs.url }} supergoodmeetings.uni.ba --scope=uniba --token=${{ secrets.VERCEL_TOKEN }}
-
-  prod:
-    if: ${{ github.ref == 'refs/heads/master' }}
+  deploy:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
devel 環境の廃止に合わせて deploy.yml を整理します。

## 変更内容
* `devel` への push トリガーを削除
* `devel` 環境向けの `preview` ジョブを削除
* 残った `prod` ジョブを `deploy` にリネーム
* トリガーが master のみになったため不要になった `if: github.ref == 'refs/heads/master'` を削除

🤖 Generated with [Claude Code](https://claude.com/claude-code)